### PR TITLE
Remove source of randomness/unpredictability

### DIFF
--- a/ntp/experiments/learn.py
+++ b/ntp/experiments/learn.py
@@ -27,6 +27,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 tf.set_random_seed(1337)
 np.random.seed(1337)
+random.seed(1337)
 
 if __name__ == '__main__':
     if len(sys.argv) > 1:


### PR DESCRIPTION
This makes output deterministic (now the loss values change at each execution).

```bash
pasquale@koeln:ntp$ PYTHONPATH=. python3 ntp/experiments/learn.py conf/synth/synth_three.conf 2>&1 | grep "Epoch 1"
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 10	Loss 30.097265243530273
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 10	Examples/s 1886.88
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 10	ETA in 00:00:01 [2.00%] 18-02-27 19:00:43
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 20	Loss 33.29855918884277
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 20	Examples/s 1727.37
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 20	ETA in 00:00:01 [4.00%] 18-02-27 19:00:43
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 30	Loss 29.90907154083252
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 30	Examples/s 1640.51
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 30	ETA in 00:00:01 [6.00%] 18-02-27 19:00:43
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 40	Loss 33.548359107971194
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 40	Examples/s 1726.51
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 40	ETA in 00:00:01 [8.00%] 18-02-27 19:00:43
pasquale@koeln:ntp$ PYTHONPATH=. python3 ntp/experiments/learn.py conf/synth/synth_three.conf 2>&1 | grep "Epoch 1"
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 10	Loss 30.097265243530273
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 10	Examples/s 1950.78
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 10	ETA in 00:00:01 [2.00%] 18-02-27 19:00:52
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 20	Loss 33.29855918884277
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 20	Examples/s 1559.43
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 20	ETA in 00:00:01 [4.00%] 18-02-27 19:00:53
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 30	Loss 29.90907154083252
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 30	Examples/s 1720.84
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 30	ETA in 00:00:01 [6.00%] 18-02-27 19:00:53
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 40	Loss 33.548359107971194
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 40	Examples/s 1603.93
INFO:ntp.jtr.util.hooks:Epoch 1	Iter 40	ETA in 00:00:01 [8.00%] 18-02-27 19:00:53
```